### PR TITLE
FIX: button需要加上type属性，不然会默认为type=submit，提交当前的表单

### DIFF
--- a/src/components/business/ControlBar/index.jsx
+++ b/src/components/business/ControlBar/index.jsx
@@ -67,6 +67,7 @@ export default class ControlBar extends React.Component {
 
         return (
           <button
+            type="button"
             key={controls.length * 2 + index}
             title={item.title}
             className={'control-item button ' + item.className}
@@ -89,6 +90,7 @@ export default class ControlBar extends React.Component {
 
         return (
           <button
+            type="button"
             key={controls.length * 2 + index}
             title={item.title}
             className={'control-item button ' + item.className}
@@ -194,6 +196,7 @@ export default class ControlBar extends React.Component {
 
               return (
                 <button
+                  type="button"
                   key={index}
                   title={controlItem.title}
                   className='control-item button'
@@ -212,6 +215,7 @@ export default class ControlBar extends React.Component {
 
               return (
                 <button
+                  type="button"
                   key={index}
                   title={controlItem.title}
                   className={buttonClassName}


### PR DESCRIPTION
当把编辑器嵌入一个form当中，编辑器里所有的button默认都是type=“submit”，这样会导致点击任何一个菜单按钮都会触发一次form的onSubmit事件