### PR TITLE
fixed dataset 不兼容IE10问题，yarn start 添加host 0.0.0.0 支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/braft.js",
   "author": "Margox",
   "scripts": {
-    "start": "webpack-dev-server -d --history-api-fallback --hot --inline --progress --colors --port 5998",
+    "start": "webpack-dev-server -d --history-api-fallback --hot --inline --progress --colors --host 0.0.0.0 --port 5998",
     "build": "rm -rf dist/ && NODE_ENV=production webpack --config webpack.config.prod.js --progress --colors",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -14,7 +14,8 @@ import { getBlockRendererFn, customBlockRenderMap, blockStyleFn, getCustomStyleM
 import ControlBar from 'components/business/ControlBar'
 import MediaLibrary from 'helpers/MediaLibrary'
 import { detectColorsFromHTML, detectColorsFromRaw } from 'helpers/colors'
-
+import DataSetPolyfill from './utils/base'
+DataSetPolyfill()
 // TODO
 // 重写convertToHTML
 // 支持mention功能

--- a/src/utils/base.js
+++ b/src/utils/base.js
@@ -9,3 +9,32 @@ export const UniqueIndex = () => {
   return window.__BRAFT_UNIQUE_INDEX__ 
 
 }
+export const transToCamelCase = (str) => {
+  var re = /_(\w)/g
+  return str.replace(re, function ($0, $1) {
+    return $1.toUpperCase()
+  })
+}
+export const DataSetPolyfill = () => {
+  if (Object.getOwnPropertyNames(HTMLElement.prototype).indexOf('dataset') === -1) {
+    Object.defineProperty(HTMLElement.prototype, 'dataset', {
+        get: function() {
+            var attributes = this.attributes;
+            var name = [],
+                value = [];
+            var obj = {};
+            for (var i = 0; i < attributes.length; i++) {
+                if (attributes[i].nodeName.slice(0, 5) == 'data-') {
+                    name.push(attributes[i].nodeName.slice(5));
+                    value.push(attributes[i].nodeValue);
+                }
+            }
+            for (var j = 0; j < name.length; j++) {
+                obj[name[j]] = value[j];
+                obj[transToCamelCase(name[j])] = value[j]; // 同时支持驼峰访问
+            }
+            return obj;
+        }
+    });
+  }
+}


### PR DESCRIPTION
添加dataSet的polyfill，yarn start 添加了 --host 0.0.0.0 支持虚拟机里用ip进行访问

-- 还有一个问题是react-hot-loader 不支持里面用的setPrototypeOf不支持IE10及以下，所以本地开发，如果要在IE10下看，需要把.babelrc中的react-hot-loader/babel 插件关掉