### PR TITLE
DOM的关联,用React 16.3 提供的createRef来替代,可以避免一些隐患, blockRenderFn的一个for循环长度缓存

### DIFF
--- a/src/components/common/DropDown/index.jsx
+++ b/src/components/common/DropDown/index.jsx
@@ -1,22 +1,21 @@
 import './style.scss'
-import React from 'react'
+import React, { createRef } from 'react'
 import ResponsiveHelper from 'helpers/responsive'
 import { BaseUtils } from 'braft-utils'
 
 export default class DropDown extends React.Component {
-
   alive = false
   responsiveResolveId = null
-  dropDownHandlerElement = null
-  dropDownContentElement = null
-  componentId = this.props.componentId || ('BRAFT-DROPDOWN-' + BaseUtils.UniqueIndex())
+  dropDownHandlerElement = createRef()
+  dropDownContentElement = createRef()
+  componentId =
+    this.props.componentId || 'BRAFT-DROPDOWN-' + BaseUtils.UniqueIndex()
   state = {
     active: false,
-    offset: 0
+    offset: 0,
   }
 
-  componentDidMount () {
-
+  componentDidMount() {
     this.alive = true
 
     document.body.addEventListener('click', (event) => {
@@ -26,40 +25,42 @@ export default class DropDown extends React.Component {
     this.responsiveResolveId = ResponsiveHelper.resolve(() => {
       this.fixDropDownPosition()
     })
-
   }
 
-  componentWillReceiveProps (next) {
-
+  componentWillReceiveProps(next) {
     if (!this.props.disabled && next.disabled) {
       this.hide()
     }
-
   }
 
-  componentDidUpdate (prevState) {
-
+  componentDidUpdate(prevState) {
     if (!prevState.active && this.state.active) {
       this.fixDropDownPosition()
     }
-
   }
 
-  componentWillUnmount () {
-
+  componentWillUnmount() {
     document.body.removeEventListener('click', (event) => {
       this.registerClickEvent(event)
     })
 
     this.alive = false
     ResponsiveHelper.unresolve(this.responsiveResolveId)
-
   }
 
-  render () {
-
+  render() {
     let { active, offset } = this.state
-    let { caption, htmlCaption, title, disabled, showArrow, arrowActive, className, children, theme } = this.props
+    let {
+      caption,
+      htmlCaption,
+      title,
+      disabled,
+      showArrow,
+      arrowActive,
+      className,
+      children,
+      theme,
+    } = this.props
 
     disabled && (active = false)
     theme === 'light' && (className = ' light-theme ' + className)
@@ -67,55 +68,59 @@ export default class DropDown extends React.Component {
     return (
       <div
         id={this.componentId}
-        className={'bf-dropdown ' + (active ? 'active ' : '') + (disabled ? 'disabled ' : '') + className}
+        className={
+          'bf-dropdown ' +
+          (active ? 'active ' : '') +
+          (disabled ? 'disabled ' : '') +
+          className
+        }
       >
         {htmlCaption ? (
           <button
-            type='button'
-            className='dropdown-handler'
+            type="button"
+            className="dropdown-handler"
             data-title={title}
             data-braft-component-id={this.componentId}
-            dangerouslySetInnerHTML={htmlCaption ? {__html: htmlCaption} : null}
-            ref={(instance) => this.dropDownHandlerElement = instance}
-          ></button>
+            dangerouslySetInnerHTML={
+              htmlCaption ? { __html: htmlCaption } : null
+            }
+            ref={this.dropDownHandlerElement}
+          />
         ) : (
           <button
-            type='button'
-            className='dropdown-handler'
+            type="button"
+            className="dropdown-handler"
             data-title={title}
             data-braft-component-id={this.componentId}
-            ref={(instance) => this.dropDownHandlerElement = instance}
+            ref={this.dropDownHandlerElement}
           >
             <span>{caption}</span>
-            {showArrow !== false ? <i className='bfi-drop-down'></i> : null}
+            {showArrow !== false ? <i className="bfi-drop-down" /> : null}
           </button>
         )}
         <div
-          className='dropdown-content'
-          style={{marginLeft: offset }}
-          ref={(instance) => this.dropDownContentElement = instance}
+          className="dropdown-content"
+          style={{ marginLeft: offset }}
+          ref={this.dropDownContentElement}
         >
           <i
-            style={{marginLeft: offset * -1}}
+            style={{ marginLeft: offset * -1 }}
             className={'dropdown-arrow' + (arrowActive ? ' active' : '')}
-          ></i>
-          <div className='dropdown-content-inner'>
-            {children}
-          </div>
+          />
+          <div className="dropdown-content-inner">{children}</div>
         </div>
       </div>
     )
-
   }
 
-  fixDropDownPosition () {
-
+  fixDropDownPosition() {
     const viewRect = this.props.containerNode.getBoundingClientRect()
-    const handlerRect = this.dropDownHandlerElement.getBoundingClientRect()
-    const contentRect = this.dropDownContentElement.getBoundingClientRect()
+    const handlerRect = this.dropDownHandlerElement.current.getBoundingClientRect()
+    const contentRect = this.dropDownContentElement.current.getBoundingClientRect()
 
     let offset = 0
-    let right = handlerRect.right - handlerRect.width / 2 + contentRect.width / 2
+    let right =
+      handlerRect.right - handlerRect.width / 2 + contentRect.width / 2
     let left = handlerRect.left + handlerRect.width / 2 - contentRect.width / 2
 
     right = viewRect.right - right
@@ -130,11 +135,9 @@ export default class DropDown extends React.Component {
     if (offset !== this.state.offset) {
       this.setState({ offset })
     }
-
   }
 
-  registerClickEvent (event) {
-
+  registerClickEvent(event) {
     let { autoHide } = this.props
     let active = false
 
@@ -145,19 +148,17 @@ export default class DropDown extends React.Component {
     }
 
     this.alive && this.setState({ active })
-
   }
 
-  show () {
+  show() {
     this.setState({
-      active: true
+      active: true,
     })
   }
 
-  hide () {
+  hide() {
     this.setState({
-      active: false
+      active: false,
     })
   }
-
 }

--- a/src/renderers/atomics/Image/index.jsx
+++ b/src/renderers/atomics/Image/index.jsx
@@ -1,11 +1,10 @@
 import './style.scss'
-import React from 'react'
+import React, { createRef } from 'react'
 import { ContentUtils } from 'braft-utils'
 import Switch from 'components/common/Switch'
 import { imageControlItems } from 'configs/controls'
 
 export default class Image extends React.Component {
-
   state = {
     toolbarVisible: false,
     toolbarOffset: 0,
@@ -13,13 +12,20 @@ export default class Image extends React.Component {
     sizeEditorVisible: false,
     tempLink: null,
     tempWidth: null,
-    tempHeight: null
+    tempHeight: null,
   }
+  toolbarElement = createRef()
+  toolbarElement = createRef()
+  mediaEmbederInstance = createRef()
 
-  render () {
-
+  render() {
     const { mediaData, language, imageControls } = this.props
-    const { toolbarVisible, toolbarOffset, linkEditorVisible, sizeEditorVisible } = this.state
+    const {
+      toolbarVisible,
+      toolbarOffset,
+      linkEditorVisible,
+      sizeEditorVisible,
+    } = this.state
     const blockData = this.props.block.getData()
 
     let float = blockData.get('float')
@@ -44,23 +50,36 @@ export default class Image extends React.Component {
     }
 
     const renderedControlItems = imageControls.map((item, index) => {
-
       if (typeof item === 'string' && imageControlItems[item]) {
         return (
-          <a className={item === 'link' && link ? 'active' : ''} key={index} href='javascript:void(0);' onClick={() => this.executeCommand(imageControlItems[item].command)}>
+          <a
+            className={item === 'link' && link ? 'active' : ''}
+            key={index}
+            href="javascript:void(0);"
+            onClick={() => this.executeCommand(imageControlItems[item].command)}
+          >
             {imageControlItems[item].text}
           </a>
         )
       } else if (item && (item.render || item.text)) {
-        return item.render ? item.render(mediaData) : <a key={index} href='javascript:void(0);' onClick={() => item.onClick && this.executeCommand(item.onClick)}>{item.text}</a>
+        return item.render ? (
+          item.render(mediaData)
+        ) : (
+          <a
+            key={index}
+            href="javascript:void(0);"
+            onClick={() => item.onClick && this.executeCommand(item.onClick)}
+          >
+            {item.text}
+          </a>
+        )
       } else {
         return null
       }
-
     })
 
     return (
-      <div className='bf-media'>
+      <div className="bf-media">
         <div
           style={imageStyles}
           draggable={true}
@@ -69,24 +88,34 @@ export default class Image extends React.Component {
           onMouseLeave={this.hideToolbar}
           onDragStart={this.handleDragStart}
           onDragEnd={this.handleDragEnd}
-          ref={instance => this.mediaEmbederInstance = instance}
-          className='bf-image'
+          ref={this.mediaEmbederInstance}
+          className="bf-image"
         >
           {toolbarVisible ? (
             <div
-              style={{marginLeft: toolbarOffset}}
-              ref={instance => this.toolbarElement = instance}
+              style={{ marginLeft: toolbarOffset }}
+              ref={this.toolbarElement}
               data-float={float}
               data-align={alignment}
-              className='bf-media-toolbar'
+              className="bf-media-toolbar"
             >
               {linkEditorVisible ? (
-                <div className='bf-image-link-editor'>
-                  <div className='editor-input-group'>
-                    <input type='text' placeholder={language.linkEditor.inputWithEnterPlaceHolder} onKeyDown={this.handleLinkInputKeyDown} onChange={this.setImageLink} defaultValue={link}/>
-                    <button type='button' onClick={this.confirmImageLink}>{language.base.confirm}</button>
+                <div className="bf-image-link-editor">
+                  <div className="editor-input-group">
+                    <input
+                      type="text"
+                      placeholder={
+                        language.linkEditor.inputWithEnterPlaceHolder
+                      }
+                      onKeyDown={this.handleLinkInputKeyDown}
+                      onChange={this.setImageLink}
+                      defaultValue={link}
+                    />
+                    <button type="button" onClick={this.confirmImageLink}>
+                      {language.base.confirm}
+                    </button>
                   </div>
-                  <div className='switch-group'>
+                  <div className="switch-group">
                     <Switch
                       active={link_target === '_blank'}
                       onClick={() => this.setImageLinkTarget(link_target)}
@@ -96,52 +125,80 @@ export default class Image extends React.Component {
                 </div>
               ) : null}
               {sizeEditorVisible ? (
-                <div className='bf-image-size-editor'>
-                  <div className='editor-input-group'>
-                    <input type='text' placeholder={language.base.width} onKeyDown={this.handleSizeInputKeyDown} onChange={this.setImageWidth} defaultValue={width}/>
-                    <input type='text' placeholder={language.base.height} onKeyDown={this.handleSizeInputKeyDown} onChange={this.setImageHeight} defaultValue={height}/>
-                    <button type='button' onClick={this.confirmImageSize}>{language.base.confirm}</button>
+                <div className="bf-image-size-editor">
+                  <div className="editor-input-group">
+                    <input
+                      type="text"
+                      placeholder={language.base.width}
+                      onKeyDown={this.handleSizeInputKeyDown}
+                      onChange={this.setImageWidth}
+                      defaultValue={width}
+                    />
+                    <input
+                      type="text"
+                      placeholder={language.base.height}
+                      onKeyDown={this.handleSizeInputKeyDown}
+                      onChange={this.setImageHeight}
+                      defaultValue={height}
+                    />
+                    <button type="button" onClick={this.confirmImageSize}>
+                      {language.base.confirm}
+                    </button>
                   </div>
                 </div>
               ) : null}
               {renderedControlItems}
-              <i style={{marginLeft: toolbarOffset * -1}} className='bf-media-toolbar-arrow'></i>
+              <i
+                style={{ marginLeft: toolbarOffset * -1 }}
+                className="bf-media-toolbar-arrow"
+              />
             </div>
           ) : null}
           <img
-            ref={instance => this.imageElement = instance}
+            ref={this.imageElement}
             src={url}
             width={width}
             height={height}
             {...meta}
           />
         </div>
-        {clearFix && <div className='clearfix' style={{clear:'both',height:0,lineHeight:0,float:'none'}}></div>}
+        {clearFix && (
+          <div
+            className="clearfix"
+            style={{ clear: 'both', height: 0, lineHeight: 0, float: 'none' }}
+          />
+        )}
       </div>
     )
-
   }
 
-  lockEditor () {
+  lockEditor() {
     this.props.editor.lockOrUnlockEditor(true)
   }
 
-  unlockEditor () {
+  unlockEditor() {
     this.props.editor.lockOrUnlockEditor(false)
   }
 
-  calcToolbarOffset () {
-
+  calcToolbarOffset() {
     if (!this.props.containerNode) {
       return 0
     }
 
-    const viewRect = this.props.containerNode.querySelector('.bf-content').getBoundingClientRect()
-    const toolbarRect = this.toolbarElement.getBoundingClientRect()
-    const imageRect = this.imageElement.getBoundingClientRect()
+    const viewRect = this.props.containerNode
+      .querySelector('.bf-content')
+      .getBoundingClientRect()
+    const toolbarRect = this.toolbarElement.current.getBoundingClientRect()
+    const imageRect = this.imageElement.current.getBoundingClientRect()
 
-    const right = viewRect.right - (imageRect.right - imageRect.width / 2 + toolbarRect.width / 2)
-    const left = (imageRect.left + imageRect.width / 2 - toolbarRect.width / 2) - viewRect.left
+    const right =
+      viewRect.right -
+      (imageRect.right - imageRect.width / 2 + toolbarRect.width / 2)
+    const left =
+      imageRect.left +
+      imageRect.width / 2 -
+      toolbarRect.width / 2 -
+      viewRect.left
 
     if (right < 10) {
       return right - 10
@@ -150,12 +207,13 @@ export default class Image extends React.Component {
     } else {
       return 0
     }
-
   }
 
   handleDragStart = () => {
-
-    if (this.props.editor.editorProps.readOnly || this.props.editor.editorProps.disabled) {
+    if (
+      this.props.editor.editorProps.readOnly ||
+      this.props.editor.editorProps.disabled
+    ) {
       return false
     }
 
@@ -163,25 +221,25 @@ export default class Image extends React.Component {
       block: this.props.block,
       mediaData: {
         type: 'IMAGE',
-        ...this.props.mediaData
-      }
+        ...this.props.mediaData,
+      },
     }
 
-    this.setState({
-      toolbarVisible: false
-    }, () => {
-      this.unlockEditor()
-    })
+    this.setState(
+      {
+        toolbarVisible: false,
+      },
+      () => {
+        this.unlockEditor()
+      },
+    )
 
     return true
-
   }
 
   handleDragEnd = () => {
-
     window.__BRAFT_DRAGING__IMAGE__ = null
     return false
-
   }
 
   executeCommand = (command) => {
@@ -194,32 +252,32 @@ export default class Image extends React.Component {
   }
 
   removeImage = () => {
-    this.props.editor.setValue(ContentUtils.removeBlock(this.props.editorState, this.props.block))
+    this.props.editor.setValue(
+      ContentUtils.removeBlock(this.props.editorState, this.props.block),
+    )
     this.unlockEditor()
   }
 
   toggleLinkEditor = () => {
     this.setState({
       linkEditorVisible: !this.state.linkEditorVisible,
-      sizeEditorVisible: false
+      sizeEditorVisible: false,
     })
   }
 
   toggleSizeEditor = () => {
     this.setState({
       linkEditorVisible: false,
-      sizeEditorVisible: !this.state.sizeEditorVisible
+      sizeEditorVisible: !this.state.sizeEditorVisible,
     })
   }
 
   handleLinkInputKeyDown = (e) => {
-
     if (e.keyCode === 13) {
       this.confirmImageLink()
     } else {
       return
     }
-
   }
 
   setImageLink = (e) => {
@@ -227,23 +285,29 @@ export default class Image extends React.Component {
     return
   }
 
-  setImageLinkTarget (link_target) {
-
+  setImageLinkTarget(link_target) {
     link_target = link_target === '_blank' ? '' : '_blank'
-    this.props.editor.setValue(ContentUtils.setMediaData(this.props.editorState, this.props.entityKey, { link_target }))
+    this.props.editor.setValue(
+      ContentUtils.setMediaData(this.props.editorState, this.props.entityKey, {
+        link_target,
+      }),
+    )
     window.setImmediate(this.props.editor.forceRender)
-
   }
 
   confirmImageLink = () => {
-
     const { tempLink: link } = this.state
 
     if (link !== null) {
-      this.props.editor.setValue(ContentUtils.setMediaData(this.props.editorState, this.props.entityKey, { link }))
+      this.props.editor.setValue(
+        ContentUtils.setMediaData(
+          this.props.editorState,
+          this.props.entityKey,
+          { link },
+        ),
+      )
       window.setImmediate(this.props.editor.forceRender)
     }
-
   }
 
   handleSizeInputKeyDown = (e) => {
@@ -255,86 +319,98 @@ export default class Image extends React.Component {
   }
 
   setImageWidth = ({ currentTarget }) => {
-
     let { value } = currentTarget
 
     value && !isNaN(value) && (value = value + 'px')
 
     this.setState({
-      tempWidth: value
+      tempWidth: value,
     })
 
     return
-
   }
 
   setImageHeight = ({ currentTarget }) => {
-
     let { value } = currentTarget
 
     value && !isNaN(value) && (value = value + 'px')
 
     this.setState({
-      tempHeight: value
+      tempHeight: value,
     })
 
     return
-
   }
 
   confirmImageSize = () => {
-
     const { tempWidth: width, tempHeight: height } = this.state
     const newImageSize = {}
 
     width !== null && (newImageSize.width = width)
     height !== null && (newImageSize.height = height)
 
-    this.props.editor.setValue(ContentUtils.setMediaData(this.props.editorState, this.props.entityKey, newImageSize))
+    this.props.editor.setValue(
+      ContentUtils.setMediaData(
+        this.props.editorState,
+        this.props.entityKey,
+        newImageSize,
+      ),
+    )
     window.setImmediate(this.props.editor.forceRender)
-
   }
 
   setImageFloat = (float) => {
-    this.props.editor.setValue(ContentUtils.setMediaPosition(this.props.editorState, this.props.block, { float }))
+    this.props.editor.setValue(
+      ContentUtils.setMediaPosition(this.props.editorState, this.props.block, {
+        float,
+      }),
+    )
     this.unlockEditor()
   }
 
   setImageAlignment = (alignment) => {
-    this.props.editor.setValue(ContentUtils.setMediaPosition(this.props.editorState, this.props.block, { alignment }))
+    this.props.editor.setValue(
+      ContentUtils.setMediaPosition(this.props.editorState, this.props.block, {
+        alignment,
+      }),
+    )
     this.unlockEditor()
   }
 
   showToolbar = (event) => {
-
-    if (this.props.editor.editorProps.readOnly || this.props.editor.editorProps.disabled) {
+    if (
+      this.props.editor.editorProps.readOnly ||
+      this.props.editor.editorProps.disabled
+    ) {
       return false
     }
 
     event.preventDefault()
 
     if (!this.state.toolbarVisible) {
-      this.setState({
-        toolbarVisible: true
-      }, () => {
-        this.lockEditor()
-        this.setState({ toolbarOffset: this.calcToolbarOffset() })
-      })
+      this.setState(
+        {
+          toolbarVisible: true,
+        },
+        () => {
+          this.lockEditor()
+          this.setState({ toolbarOffset: this.calcToolbarOffset() })
+        },
+      )
     }
-
   }
 
   hideToolbar = (event) => {
-
     event.preventDefault()
 
-    this.setState({
-      toolbarVisible: false
-    }, () => {
-      this.unlockEditor()
-      this.props.editor.requestFocus()
-    })
-
+    this.setState(
+      {
+        toolbarVisible: false,
+      },
+      () => {
+        this.unlockEditor()
+        this.props.editor.requestFocus()
+      },
+    )
   }
-
 }

--- a/src/renderers/block/blockRendererFn.js
+++ b/src/renderers/block/blockRendererFn.js
@@ -7,7 +7,6 @@ import HorizontalLine from 'renderers/atomics/HorizontalLine'
 import { getExtensionBlockRendererFns } from 'helpers/extension'
 
 const getAtomicBlockComponent = (superProps) => (props) => {
-
   const entityKey = props.block.getEntityAt(0)
 
   if (!entityKey) {
@@ -20,24 +19,25 @@ const getAtomicBlockComponent = (superProps) => (props) => {
   const mediaProps = {
     ...superProps,
     block: props.block,
-    mediaData, entityKey
+    mediaData,
+    entityKey,
   }
 
   if (mediaType === 'IMAGE') {
-    return <Image { ...mediaProps } />
+    return <Image {...mediaProps} />
   } else if (mediaType === 'AUDIO') {
-    return <Audio { ...mediaProps } />
+    return <Audio {...mediaProps} />
   } else if (mediaType === 'VIDEO') {
-    return <Video { ...mediaProps } />
+    return <Video {...mediaProps} />
   } else if (mediaType === 'EMBED') {
-    return <Embed { ...mediaProps } />
+    return <Embed {...mediaProps} />
   } else if (mediaType === 'HR') {
-    return <HorizontalLine { ...mediaProps } />
+    return <HorizontalLine {...mediaProps} />
   }
 
   if (superProps.extendAtomics) {
     const atomics = superProps.extendAtomics
-    for (let i = 0; i < atomics.length; i++) {
+    for (let i = 0, j = atomics.length; i < j; i++) {
       if (mediaType === atomics[i].type) {
         const Component = atomics[i].component
         return <Component {...mediaProps} />
@@ -46,11 +46,9 @@ const getAtomicBlockComponent = (superProps) => (props) => {
   }
 
   return null
-
 }
 
 export default (superProps, customBlockRendererFn) => (block) => {
-
   const blockType = block.getType()
   let blockRenderer = null
 
@@ -62,10 +60,15 @@ export default (superProps, customBlockRendererFn) => (block) => {
     return blockRenderer
   }
 
-  const extensionBlockRendererFns = getExtensionBlockRendererFns(superProps.editorId)
+  const extensionBlockRendererFns = getExtensionBlockRendererFns(
+    superProps.editorId,
+  )
 
-  extensionBlockRendererFns.find(item => {
-    if (item.blockType === blockType || (item.blockType instanceof RegExp && item.blockType.test(blockType))) {
+  extensionBlockRendererFns.find((item) => {
+    if (
+      item.blockType === blockType ||
+      (item.blockType instanceof RegExp && item.blockType.test(blockType))
+    ) {
       blockRenderer = item.rendererFn ? item.rendererFn(superProps) : null
       return true
     }
@@ -78,10 +81,9 @@ export default (superProps, customBlockRendererFn) => (block) => {
   if (blockType === 'atomic') {
     blockRenderer = {
       component: getAtomicBlockComponent(superProps),
-      editable: false
+      editable: false,
     }
   }
 
   return blockRenderer
-
 }


### PR DESCRIPTION
Signed-off-by: CRPER <crper@outlook.com>

DOM的关联,用React 16.3 提供的createRef来替代,可以避免一些隐患, 

blockRenderFn的一个for循环长度缓存了
