### PR TITLE
修复传入数字字符串生成empty EditorState bug

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -43,6 +43,8 @@ BraftEditor.createEditorState = EditorState.createFrom = (content, options = {})
     } catch (error) {
       editorState = convertHTMLToEditorState(content, getDecorators(options.editorId), options, 'create')
     }
+  } else if (typeof content === 'number') {
+    editorState = convertHTMLToEditorState(`${content}`, getDecorators(options.editorId), options, 'create')
   } else {
     editorState = EditorState.createEmpty(getDecorators(options.editorId))
   }


### PR DESCRIPTION
在createEditorState的时候传入数字字符串，比如'1'，会生成一个空的EditorState