### PR TITLE
fix: js精度丢失和JSON.parse出现科学计数法

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -39,7 +39,11 @@ BraftEditor.createEditorState = EditorState.createFrom = (content, options = {})
     editorState = convertRawToEditorState(content, getDecorators(options.editorId))
   } else if (typeof content === 'string') {
     try {
-      editorState = EditorState.createFrom(JSON.parse(content), options)
+      if (!/^(\-)?\d{1,15}$/.test(content)) {
+        editorState = convertHTMLToEditorState(content, getDecorators(options.editorId), options, 'create')
+      } else {
+        editorState = EditorState.createFrom(JSON.parse(content), options)
+      }
     } catch (error) {
       editorState = convertHTMLToEditorState(content, getDecorators(options.editorId), options, 'create')
     }


### PR DESCRIPTION
BraftEditor.createEditorState传入纯数字字符串的时候，会出现精度丢失问题和转义问题（21位以后变成科学计数法）