### PR TITLE
 fix: js精度丢失和JSON.parse出现科学计数法

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -39,7 +39,7 @@ BraftEditor.createEditorState = EditorState.createFrom = (content, options = {})
     editorState = convertRawToEditorState(content, getDecorators(options.editorId))
   } else if (typeof content === 'string') {
     try {
-      if (!/^(\-)?\d{1,15}$/.test(content)) {
+      if (!/^(-)?\d{1,15}$/.test(content)) {
         editorState = convertHTMLToEditorState(content, getDecorators(options.editorId), options, 'create')
       } else {
         editorState = EditorState.createFrom(JSON.parse(content), options)

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -39,7 +39,11 @@ BraftEditor.createEditorState = EditorState.createFrom = (content, options = {})
     editorState = convertRawToEditorState(content, getDecorators(options.editorId))
   } else if (typeof content === 'string') {
     try {
-      editorState = EditorState.createFrom(JSON.parse(content), options)
+      if (!/^(\-)?\d{1,15}$/.test(content)) {
+        editorState = convertHTMLToEditorState(content, getDecorators(options.editorId), options, 'create')
+      } else {
+        editorState = EditorState.createFrom(JSON.parse(content), options)
+      }
     } catch (error) {
       editorState = convertHTMLToEditorState(content, getDecorators(options.editorId), options, 'create')
     }


### PR DESCRIPTION
BraftEditor.createEditorState参数是纯数字字符串的时候，会出现精度丢失问题和转义问题（超过21位出现科学计数法，16-21之间可能会出现精度丢失问题）