### PR TITLE
fix: multiple render & behavior of onChange

### DIFF
--- a/src/components/business/ControlBar/index.jsx
+++ b/src/components/business/ControlBar/index.jsx
@@ -178,9 +178,9 @@ export default class ControlBar extends React.Component {
 
   render() {
 
-    const { editor, editorId, editorState, className, style, controls, media, extendControls, language, hooks, colors, colorPicker, colorPickerTheme, colorPickerAutoHide, fontSizes, fontFamilies, emojis, containerNode, lineHeights, letterSpacings, textAligns, textBackgroundColor, defaultLinkTarget } = this.props
+    const { editor, editorId, editorState, className, style, controls, media, extendControls, language, hooks, colors, colorPicker, colorPickerTheme, colorPickerAutoHide, fontSizes, fontFamilies, emojis, getContainerNode, lineHeights, letterSpacings, textAligns, textBackgroundColor, defaultLinkTarget } = this.props
     const currentBlockType = ContentUtils.getSelectionBlockType(editorState)
-    const commonProps = { editor, editorId, editorState, language, containerNode, hooks }
+    const commonProps = { editor, editorId, editorState, language, getContainerNode, hooks }
 
     const renderedControls = []
     const editorControls = getEditorControls(language, editor)

--- a/src/components/business/EmojiPicker/index.jsx
+++ b/src/components/business/EmojiPicker/index.jsx
@@ -28,7 +28,7 @@ export default (props) => {
       caption={props.defaultCaption}
       autoHide={true}
       showArrow={false}
-      containerNode={props.containerNode}
+      getContainerNode={props.getContainerNode}
       title={props.language.controls.emoji}
       className={'control-item dropdown bf-emoji-dropdown'}
     >

--- a/src/components/business/FontFamily/index.jsx
+++ b/src/components/business/FontFamily/index.jsx
@@ -39,7 +39,7 @@ export default (props) => {
   return (
     <DropDown
       caption={caption || props.defaultCaption}
-      containerNode={props.containerNode}
+      getContainerNode={props.getContainerNode}
       title={props.language.controls.fontFamily}
       autoHide={true}
       arrowActive={currentIndex === 0}

--- a/src/components/business/FontSize/index.jsx
+++ b/src/components/business/FontSize/index.jsx
@@ -40,7 +40,7 @@ export default (props) => {
     <DropDown
       autoHide={true}
       caption={caption || props.defaultCaption}
-      containerNode={props.containerNode}
+      getContainerNode={props.getContainerNode}
       title={props.language.controls.fontSize}
       ref={(instance) => dropDownInstance = instance}
       className={'control-item dropdown bf-font-size-dropdown'}

--- a/src/components/business/Headings/index.jsx
+++ b/src/components/business/Headings/index.jsx
@@ -15,7 +15,7 @@ export default (props) => {
     <DropDown
       caption={caption}
       autoHide={true}
-      containerNode={props.containerNode}
+      getContainerNode={props.getContainerNode}
       title={props.language.controls.headings}
       arrowActive={currentHeadingIndex === 0}
       ref={(instance) => dropDownInstance = instance}

--- a/src/components/business/LetterSpacing/index.jsx
+++ b/src/components/business/LetterSpacing/index.jsx
@@ -40,7 +40,7 @@ export default (props) => {
     <DropDown
       autoHide={true}
       caption={caption || props.defaultCaption}
-      containerNode={props.containerNode}
+      getContainerNode={props.getContainerNode}
       title={props.language.controls.letterSpacing}
       ref={(instance) => dropDownInstance = instance}
       className={'control-item dropdown bf-letter-spacing-dropdown'}

--- a/src/components/business/LineHeight/index.jsx
+++ b/src/components/business/LineHeight/index.jsx
@@ -40,7 +40,7 @@ export default (props) => {
     <DropDown
       autoHide={true}
       caption={caption || props.defaultCaption}
-      containerNode={props.containerNode}
+      getContainerNode={props.getContainerNode}
       title={props.language.controls.lineHeight}
       ref={(instance) => dropDownInstance = instance}
       className={'control-item dropdown bf-line-height-dropdown'}

--- a/src/components/business/LinkEditor/index.jsx
+++ b/src/components/business/LinkEditor/index.jsx
@@ -43,7 +43,7 @@ export default class LinkEditor extends React.Component {
           caption={caption}
           title={this.props.language.controls.link}
           autoHide={true}
-          containerNode={this.props.containerNode}
+          getContainerNode={this.props.getContainerNode}
           showArrow={false}
           disabled={!textSelected}
           ref={(instance) => this.dropDownInstance = instance}

--- a/src/components/business/TextColor/index.jsx
+++ b/src/components/business/TextColor/index.jsx
@@ -48,7 +48,7 @@ export default class TextColor extends React.Component {
         showArrow={false}
         autoHide={this.props.autoHide}
         theme={this.props.theme}
-        containerNode={this.props.containerNode}
+        getContainerNode={this.props.getContainerNode}
         ref={(instance) => this.dropDownInstance = instance}
         className={'control-item dropdown text-color-dropdown'}
       >

--- a/src/components/common/DropDown/index.jsx
+++ b/src/components/common/DropDown/index.jsx
@@ -93,7 +93,7 @@ export default class DropDown extends React.Component {
 
   fixDropDownPosition = () => {
 
-    const viewRect = this.props.containerNode.getBoundingClientRect()
+    const viewRect = this.props.getContainerNode().getBoundingClientRect()
     const handlerRect = this.dropDownHandlerElement.getBoundingClientRect()
     const contentRect = this.dropDownContentElement.getBoundingClientRect()
 

--- a/src/renderers/atomics/Image/index.jsx
+++ b/src/renderers/atomics/Image/index.jsx
@@ -193,12 +193,12 @@ export default class Image extends React.Component {
   }
 
   calcToolbarOffset () {
-
-    if (!this.props.containerNode) {
+    const containerNode = this.props.getContainerNode()
+    if (!containerNode) {
       return 0
     }
 
-    const viewRect = this.props.containerNode.querySelector('.bf-content').getBoundingClientRect()
+    const viewRect = containerNode.querySelector('.bf-content').getBoundingClientRect()
     const toolbarRect = this.toolbarElement.getBoundingClientRect()
     const imageRect = this.imageElement.getBoundingClientRect()
 


### PR DESCRIPTION
**第一个事情**
当前该富文本组件在第一次挂载后会有多余的render，主要是在 componentDidMount 和 setEditorContainerNode 会引发多余的 render。

关于 componentDidMount 中所做的事情我想都是可以移到 constructor 中来完成的。

关于 containerNode 不需要作为 state 来处理，详见代码。我这里还有的问题是 containerNode 的作用是什么，粗略的看了源码不是很理解，写的逻辑好像并未有什么作用。

**第二个事情**
当前组件 onChange 的事件触发时机是及其不合理的，初始化会触发 onChange，组件的 value 属性变化也会触发。我想 react 中的触发 onChange 的理念应该是在**用户行为**导致组件内部状态发生变化的时候。