### PR TITLE
修复高阶函数 getBlockRendererFn 每次执行返回新返回值导致 react 重新 mount 组件的问题

### DIFF
--- a/src/renderers/block/blockRendererFn.js
+++ b/src/renderers/block/blockRendererFn.js
@@ -6,82 +6,97 @@ import Embed from 'renderers/atomics/Embed'
 import HorizontalLine from 'renderers/atomics/HorizontalLine'
 import { getExtensionBlockRendererFns } from 'helpers/extension'
 
-const getAtomicBlockComponent = (superProps) => (props) => {
+class BlockRenderFnContext {
+  superProps
+  customBlockRendererFn
 
-  const entityKey = props.block.getEntityAt(0)
+  getRenderFn = (superProps, customBlockRendererFn) => {
+    this.superProps = superProps
+    this.customBlockRendererFn = customBlockRendererFn
 
-  if (!entityKey) {
+    return this.blockRendererFn
+  }
+
+  renderAtomicBlock = (props) => {
+    const { superProps } = this
+
+    const entityKey = props.block.getEntityAt(0)
+
+    if (!entityKey) {
+      return null
+    }
+
+    const entity = props.contentState.getEntity(entityKey)
+    const mediaData = entity.getData()
+    const mediaType = entity.getType()
+    const mediaProps = {
+      ...superProps,
+      block: props.block,
+      mediaData, entityKey
+    }
+
+    if (mediaType === 'IMAGE') {
+      return <Image { ...mediaProps } />
+    } else if (mediaType === 'AUDIO') {
+      return <Audio { ...mediaProps } />
+    } else if (mediaType === 'VIDEO') {
+      return <Video { ...mediaProps } />
+    } else if (mediaType === 'EMBED') {
+      return <Embed { ...mediaProps } />
+    } else if (mediaType === 'HR') {
+      return <HorizontalLine { ...mediaProps } />
+    }
+
+    if (superProps.extendAtomics) {
+      const atomics = superProps.extendAtomics
+      for (let i = 0; i < atomics.length; i++) {
+        if (mediaType === atomics[i].type) {
+          const Component = atomics[i].component
+          return <Component {...mediaProps} />
+        }
+      }
+    }
+
     return null
   }
 
-  const entity = props.contentState.getEntity(entityKey)
-  const mediaData = entity.getData()
-  const mediaType = entity.getType()
-  const mediaProps = {
-    ...superProps,
-    block: props.block,
-    mediaData, entityKey
-  }
+  blockRendererFn = (block) => {
+    const { customBlockRendererFn, superProps } = this
 
-  if (mediaType === 'IMAGE') {
-    return <Image { ...mediaProps } />
-  } else if (mediaType === 'AUDIO') {
-    return <Audio { ...mediaProps } />
-  } else if (mediaType === 'VIDEO') {
-    return <Video { ...mediaProps } />
-  } else if (mediaType === 'EMBED') {
-    return <Embed { ...mediaProps } />
-  } else if (mediaType === 'HR') {
-    return <HorizontalLine { ...mediaProps } />
-  }
+    const blockType = block.getType()
+    let blockRenderer = null
 
-  if (superProps.extendAtomics) {
-    const atomics = superProps.extendAtomics
-    for (let i = 0; i < atomics.length; i++) {
-      if (mediaType === atomics[i].type) {
-        const Component = atomics[i].component
-        return <Component {...mediaProps} />
+    if (customBlockRendererFn) {
+      blockRenderer = customBlockRendererFn(block, superProps) || null
+    }
+
+    if (blockRenderer) {
+      return blockRenderer
+    }
+
+    const extensionBlockRendererFns = getExtensionBlockRendererFns(superProps.editorId)
+
+    extensionBlockRendererFns.find(item => {
+      if (item.blockType === blockType || (item.blockType instanceof RegExp && item.blockType.test(blockType))) {
+        blockRenderer = item.rendererFn ? item.rendererFn(superProps) : null
+        return true
+      }
+    })
+
+    if (blockRenderer) {
+      return blockRenderer
+    }
+
+    if (blockType === 'atomic') {
+      blockRenderer = {
+        component: this.renderAtomicBlock,
+        editable: false
       }
     }
-  }
 
-  return null
-
-}
-
-export default (superProps, customBlockRendererFn) => (block) => {
-
-  const blockType = block.getType()
-  let blockRenderer = null
-
-  if (customBlockRendererFn) {
-    blockRenderer = customBlockRendererFn(block, superProps) || null
-  }
-
-  if (blockRenderer) {
     return blockRenderer
   }
-
-  const extensionBlockRendererFns = getExtensionBlockRendererFns(superProps.editorId)
-
-  extensionBlockRendererFns.find(item => {
-    if (item.blockType === blockType || (item.blockType instanceof RegExp && item.blockType.test(blockType))) {
-      blockRenderer = item.rendererFn ? item.rendererFn(superProps) : null
-      return true
-    }
-  })
-
-  if (blockRenderer) {
-    return blockRenderer
-  }
-
-  if (blockType === 'atomic') {
-    blockRenderer = {
-      component: getAtomicBlockComponent(superProps),
-      editable: false
-    }
-  }
-
-  return blockRenderer
-
 }
+
+const blockRenderFnContext = new BlockRenderFnContext()
+export default blockRenderFnContext.getRenderFn


### PR DESCRIPTION
相关 issue：https://github.com/margox/braft-editor/issues/498

这个根本原因是，之前 getAtomicBlockComponent 的实现是这样的：
```
getAtomicBlockComponent = () => () => {}
```

这导致每次 braft render，传给 draft 的 blockRendererFn 的返回值的 .component 属性都是一个全新的函数，这种情况 React diff 的时候会认为是两个不同类型的组件发生替换，就会销毁旧的渲染新的。 