### PR TITLE
Fix Russian language definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,6 +29,7 @@ export interface BraftEditorProps {
     | 'zh-hant'
     | 'en'
     | 'tr'
+    | 'ru'
     | 'pl'
     | ((languages: any, context: any) => any);
   controls?: ControlType[];

--- a/src/languages/index.js
+++ b/src/languages/index.js
@@ -3,6 +3,7 @@ import zh from './zh'
 import zhHant from './zh-hant'
 import pl from './pl'
 import kr from './kr'
+import ru from './ru'
 import tr from './tr'
 import jpn from './jpn'
 
@@ -12,6 +13,7 @@ export default {
   'zh-hant': zhHant,
   'pl': pl,
   'kr': kr,
+  'ru': ru,
   'tr': tr,
   'jpn': jpn
 }


### PR DESCRIPTION
You accepted pull request for Russian language, however, that commit only added to `dist/`. This means, when you build a new version, Russian language will be removed.

This ensures language will be available between versions.


See: https://github.com/margox/braft-editor/pull/519

/cc @TheComedian08