### PR TITLE
add max-width for video just same as the img

### DIFF
--- a/src/assets/scss/output.scss
+++ b/src/assets/scss/output.scss
@@ -4,7 +4,8 @@
     min-height: 1em;
   }
 
-  .image-wrap img{
+  .image-wrap img,
+  .video-wrap video{
     max-width: 100%;
     height: auto;
   }


### PR DESCRIPTION
We should make same styles for both video and image when previewing a media.