### PR TITLE
feat 添加关于braft-extensions/dist/max-length插件的自定义属性声明

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,7 @@ export interface BraftEditorProps {
   blockRendererFn?: Function;
   converts?: object;
   hooks?: HooksType;
+  maxLength?: number;
   textBackgroundColor?: boolean;
   allowInsertLinkText?: boolean;
   defaultLinkTarget?: string;
@@ -82,6 +83,7 @@ export interface BraftEditorProps {
   handleBeforeInput?: Function;
   handleReturn?: Function;
   handleKeyCommand?: Function;
+  onReachMaxLength?: Function;
 }
 
 export default class BraftEditor extends React.Component<BraftEditorProps> {


### PR DESCRIPTION
使用MaxLength扩展之后，可为编辑器组件传入maxLength和onReachMaxLength。但是braft-editor的ts声明文件中没有声明这两个属性，这次提交就是在index.d.ts中加上这两个声明。